### PR TITLE
 # Python >= 3.0 command

### DIFF
--- a/docs/dev-setup.rst
+++ b/docs/dev-setup.rst
@@ -48,7 +48,7 @@ Next run a basic HTTP server with Python:
     # Python <= 2.7
     python -m SimpleHTTPServer
     # Python >= 3.0
-    python -m http.server
+    python3 -m http.server
 
 Now visit http://localhost:8000/ in your browser.
 


### PR DESCRIPTION
 # Python >= 3.0
    python -m http.server

adding the 3 at the end of python makes it more explicit, if you have python2 and python3 installed
 # Python >= 3.0
    python3 -m http.server
# Please let me know if this is incorrect. Thank you!
